### PR TITLE
[BUGFIX] Fix special chars in mail subject and plain text

### DIFF
--- a/Resources/Private/Partials/MailRequest.html
+++ b/Resources/Private/Partials/MailRequest.html
@@ -1,5 +1,5 @@
 <f:section name="Subject">
-    <f:translate key="requestNewPassword.subject" extensionName="CdsrcBepwreset" arguments="{0:siteName}"/>
+    <f:format.raw><f:translate key="requestNewPassword.subject" extensionName="CdsrcBepwreset" arguments="{0:siteName}"/></f:format.raw>
 </f:section>
 
 <f:section name="Html">
@@ -23,9 +23,9 @@
 </f:section>
 
 <f:section name="Plain">
-Hi{f:if(condition:user.realName, then:' {user.realName}')},
+Hi{f:if(condition:user.realName, then:' {user.realName -> f:format.raw()}')},
 
-Password reset has been requested for user "{user.username}".
+Password reset has been requested for user "{user.username -> f:format.raw()}".
 Please click on this link if you did this request (valid until {validity -> f:format.date(format:'d.m.Y H:i')})
 {url -> f:format.raw()}
 

--- a/Resources/Private/Partials/de.MailRequest.html
+++ b/Resources/Private/Partials/de.MailRequest.html
@@ -20,9 +20,9 @@
 </f:section>
 
 <f:section name="Plain">
-    Hallo {f:if(condition:user.realName, then:' {user.realName}')},
+    Hallo {f:if(condition:user.realName, then:' {user.realName -> f:format.raw()}')},
 
-    Sie haben für Ihren Benutzer "{user.username}" ein neues Passwort angefordert.
+    Sie haben für Ihren Benutzer "{user.username -> f:format.raw()}" ein neues Passwort angefordert.
 
     Um den Prozess abzuschließen, klicken Sie bitte auf folgenden Link: {url -> f:format.raw()}
     Dieser Link ist gültig bis zum {validity -> f:format.date(format:'d.m.Y H:i')} Uhr.


### PR DESCRIPTION
If the site name, user real name or username contain special characters they are encoded in the mail subject and plain text mail.