### PR TITLE
Optimize version constraints for typo3/cms-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "typo3/cms-core": ">= 8.7.0, <= 9.5.99"
+    "typo3/cms-core": "^8.7||^9.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
ATM you can't require this extension while using the latest dev version of typo3 as `9.5.x-dev` is higher than `9.5.99`.
As an alternative you could define it  as ">= 8.7.0, <10".