### PR TITLE
[BUGFIX] Disable password reset for switch user functionality

### DIFF
--- a/Classes/Hooks/UserAuthHook.php
+++ b/Classes/Hooks/UserAuthHook.php
@@ -34,14 +34,16 @@ class UserAuthHook
      * Log off and redirect if password reset is required
      * @param array $params
      * @param BackendUserAuthentication $pObj
-     * 
+     *
      * @throws \Exception
      */
     public function postUserLookUp($params, $pObj)
     {
         if ($pObj instanceof BackendUserAuthentication) {
             if (!empty($pObj->user)) {
-                if (intval($pObj->user['tx_cdsrcbepwreset_resetAtNextLogin']) === 1) {
+                if (intval($pObj->user['tx_cdsrcbepwreset_resetAtNextLogin']) === 1
+                    && (int)($pObj->user['ses_backuserid'] ?? 0) <= 0
+                ) {
                     try {
                         $user = $pObj->user;
                         /** @var ResetTool $resetTool */


### PR DESCRIPTION
When an admin switches the backend to another backend user, the password reset functionality must not be executed. Otherwise, the switch user functionality is not working properly, because it explicitly performs a logout on the backend user object.